### PR TITLE
v0.38.6

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,15 @@ be method matched to Spreadsheet::ParseExcel prior to the 1.0 release.
 	
 	* Another cool change
 
+v0.38.6   2015-06-30 06:13:36-07:00 America/Los_Angeles
+	
+	! Some general documentation updates for the FmtDefault class that were not done correct for the last release
+		Doh!
+	+ Added the possibility of passing a closure to the set_headers for header value scrubbing
+	+ Adjusted the :just_the_data flag
+		cache_positions   => 1, (documented as added but not added last commit)
+		from_the_edge     => 0,
+
 v0.38.4   2015-06-29 17:17:07-07:00 America/Los_Angeles
 
 	! The first Alien::LibXML change failed - trying again

--- a/META.json
+++ b/META.json
@@ -81,63 +81,63 @@
    "provides" : {
       "Spreadsheet::XLSX::Reader::LibXML" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::Cell" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/Cell.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::CellToColumnRow" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/CellToColumnRow.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::Error" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/Error.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::FmtDefault" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/FmtDefault.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::GetCell" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/GetCell.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/ParseExcelFormatStrings.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::Types" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/Types.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::XMLReader" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::XMLReader::CalcChain" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/CalcChain.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::XMLReader::Chartsheet" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Chartsheet.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::XMLReader::SharedStrings" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/SharedStrings.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::XMLReader::Styles" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Styles.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::XMLReader::Worksheet" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Worksheet.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       },
       "Spreadsheet::XLSX::Reader::LibXML::XMLReader::XMLToPerlData" : {
          "file" : "lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/XMLToPerlData.pm",
-         "version" : "v0.38.4"
+         "version" : "v0.38.6"
       }
    },
    "release_status" : "stable",
@@ -152,7 +152,7 @@
          "web" : "https://github.com/jandrew/Spreadsheet-XLSX-Reader-LibXML"
       }
    },
-   "version" : "v0.38.4",
+   "version" : "v0.38.6",
    "x_authority" : "cpan:JANDREW"
 }
 

--- a/META.yml
+++ b/META.yml
@@ -40,49 +40,49 @@ name: Spreadsheet-XLSX-Reader-LibXML
 provides:
   Spreadsheet::XLSX::Reader::LibXML:
     file: lib/Spreadsheet/XLSX/Reader/LibXML.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::Cell:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/Cell.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::CellToColumnRow:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/CellToColumnRow.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::Error:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/Error.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::FmtDefault:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/FmtDefault.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::GetCell:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/GetCell.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/ParseExcelFormatStrings.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::Types:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/Types.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::XMLReader:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::XMLReader::CalcChain:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/CalcChain.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::XMLReader::Chartsheet:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Chartsheet.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::XMLReader::SharedStrings:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/SharedStrings.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::XMLReader::Styles:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Styles.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::XMLReader::Worksheet:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Worksheet.pm
-    version: v0.38.4
+    version: v0.38.6
   Spreadsheet::XLSX::Reader::LibXML::XMLReader::XMLToPerlData:
     file: lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/XMLToPerlData.pm
-    version: v0.38.4
+    version: v0.38.6
 requires:
   Archive::Zip: '0'
   Carp: '0'
@@ -113,5 +113,5 @@ resources:
   bugtracker: https://github.com/jandrew/Spreadsheet-XLSX-Reader-LibXML/issues
   homepage: https://github.com/jandrew/Spreadsheet-XLSX-Reader-LibXML
   repository: https://github.com/jandrew/Spreadsheet-XLSX-Reader-LibXML.git
-version: v0.38.4
+version: v0.38.6
 x_authority: cpan:JANDREW

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -70,7 +70,7 @@ my %WriteMakefileArgs = (
     "XML::LibXML::Reader" => 0,
     "version" => "0.77"
   },
-  "VERSION" => "v0.38.4",
+  "VERSION" => "v0.38.6",
   "test" => {
     "TESTS" => "t/Spreadsheet/XLSX/Reader/*.t t/Spreadsheet/XLSX/Reader/LibXML/*.t t/Spreadsheet/XLSX/Reader/LibXML/XMLReader/*.t"
   }

--- a/README.pod
+++ b/README.pod
@@ -19,7 +19,7 @@ Spreadsheet::XLSX::Reader::LibXML - Read xlsx spreadsheet files with LibXML
 </a>
 
 <a>
-	<img src="https://img.shields.io/badge/this version-0.36.24-brightgreen.svg" alt="this version">
+	<img src="https://img.shields.io/badge/this version-0.38.6-brightgreen.svg" alt="this version">
 </a>
 
 <a href="https://metacpan.org/pod/Spreadsheet::XLSX::Reader::LibXML">
@@ -173,9 +173,9 @@ B<2.> This package requires that you can load L<XML::LibXML> which requires the 
 the build profile in an attempt to resolve any library issues but being new to usage of 
 Alien libraries in general I'm not certain I got it quite right.  Many OS's have these 
 libraries installed as part of their core but if this package fails to load please log an 
-issue in my repo on L<github|/SUPPORT>>.  On the other hand the correct libraries are 
-loading on travis-ci during the builds so if no issue is logged before then I will remove 
-this warning on 2/1/2016.
+issue in my repo on L<github|/SUPPORT>.  On the other hand the correct libraries are 
+loading on travis-ci during the builds so if no issue is logged before then I will B<remove 
+this warning on 2/1/2016.>
 
 B<3.> Not all workbook sheets (tabs) are created equal!  Some Excel sheet tabs are only a 
 chart.  These tabs are 'chartsheets'.  The methods with 'worksheet' in the name only act on 
@@ -187,18 +187,20 @@ classes do not provide access to cells.
 
 B<4.> L<HMBRAND|https://metacpan.org/author/HMBRAND> pointed out that the formatter portion of 
 this package does not follow the L<Spreadsheet::ParseExcel API|Spreadsheet::ParseExcel/Formatter-Class> 
-for the formatter class.  I suppose this was, in part, laziness on my part.  In an effort to 
-L<partially|Spreadsheet::XLSX::Reader::LibXML::FmtDefault/DESCRIPTION> 
-comply with goal #2 of this sheet I have updated the API so that L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault> 
-is a stand alone class (not a role).  This more closely follows Spreadsheet::ParseExcel.  And 
-incidentally probably makes building alternate formatting modules easier.  I<The formatters will 
-still not exchange back and forth between L<Spreadsheet::ParseExcel::FmtDefault> and back since 
-they are both built to interface with fundamentally different architecture.>  This also affects 
-the role L<Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings> and how it is consumed.  If 
-you wrote your own formatter for this package that interfaces in the old way I would be willing 
+for the formatter class.  I suppose this was, in part, laziness.  In an effort to partially 
+comply with goal #2 of this sheet I have updated the API so that it the formatter is a stand-alone 
+class.  For details of the implemenation see L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault/CLASS DESCRIPTION> 
+This more closely follows Spreadsheet::ParseExcel, and incidentally probably makes building alternate 
+formatting modules easier.  I<The formatters will still not exchange back and forth between 
+L<Spreadsheet::ParseExcel::FmtDefault> and back since they are both built to interface with 
+fundamentally different architecture.>  This also affects the role 
+L<Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings> and how it is consumed.  If 
+you wrote your own formatter for this package for the old way I would be willing 
 to provide troubleshooting support for the transition to the the new API.  However if you are 
-setting specific formats today using get_defined_excel_format( $pos ) it should still work.  
-(Moose delegation is a wonderful thing) This warning will be removed on 2/1/2016.
+setting specific formats today using set_defined_excel_format_list you should be able to switch to
+L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault/set_defined_excel_formats( %args )> or use the 
+attribute L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault/defined_excel_translations>.    B<This warning 
+will be removed on 2/1/2016.>
 
 =head2 Attributes
 
@@ -1232,6 +1234,8 @@ L<empty_is_end|/empty_is_end> => 1
 L<group_return_type|/group_return_type> => 'value'
 
 L<cache_positions|/cache_positions> => 1
+
+L<from_the_edge|/from_the_edge> => 0,
 
 =back
 

--- a/lib/Spreadsheet/XLSX/Reader/LibXML.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML;
-use version 0.77; our $VERSION = qv('v0.38.4');
+use version 0.77; our $VERSION = qv('v0.38.6');
 
 use 5.010;
 use	List::Util 1.33;
@@ -103,7 +103,8 @@ my	$flag_settings ={
 			values_only       => 1,
 			empty_is_end      => 1,
 			group_return_type => 'value',
-			cache_positions => 1
+			cache_positions   => 1,
+			from_the_edge     => 0,
 		},
 	};
 
@@ -141,7 +142,7 @@ has format_inst =>(
 		handles =>[qw(
 						get_defined_excel_format 	parse_excel_format_string
 						change_output_encoding		set_date_behavior
-						get_date_behavior			)],
+						get_date_behavior			set_defined_excel_formats)],
 		trigger => \&_import_format_settings,
 	);
 	
@@ -963,7 +964,7 @@ Spreadsheet::XLSX::Reader::LibXML - Read xlsx spreadsheet files with LibXML
 </a>
 
 <a>
-	<img src="https://img.shields.io/badge/this version-0.36.24-brightgreen.svg" alt="this version">
+	<img src="https://img.shields.io/badge/this version-0.38.6-brightgreen.svg" alt="this version">
 </a>
 
 <a href="https://metacpan.org/pod/Spreadsheet::XLSX::Reader::LibXML">
@@ -1117,9 +1118,9 @@ B<2.> This package requires that you can load L<XML::LibXML> which requires the 
 the build profile in an attempt to resolve any library issues but being new to usage of 
 Alien libraries in general I'm not certain I got it quite right.  Many OS's have these 
 libraries installed as part of their core but if this package fails to load please log an 
-issue in my repo on L<github|/SUPPORT>>.  On the other hand the correct libraries are 
-loading on travis-ci during the builds so if no issue is logged before then I will remove 
-this warning on 2/1/2016.
+issue in my repo on L<github|/SUPPORT>.  On the other hand the correct libraries are 
+loading on travis-ci during the builds so if no issue is logged before then I will B<remove 
+this warning on 2/1/2016.>
 
 B<3.> Not all workbook sheets (tabs) are created equal!  Some Excel sheet tabs are only a 
 chart.  These tabs are 'chartsheets'.  The methods with 'worksheet' in the name only act on 
@@ -1131,18 +1132,20 @@ classes do not provide access to cells.
 
 B<4.> L<HMBRAND|https://metacpan.org/author/HMBRAND> pointed out that the formatter portion of 
 this package does not follow the L<Spreadsheet::ParseExcel API|Spreadsheet::ParseExcel/Formatter-Class> 
-for the formatter class.  I suppose this was, in part, laziness on my part.  In an effort to 
-L<partially|Spreadsheet::XLSX::Reader::LibXML::FmtDefault/DESCRIPTION> 
-comply with goal #2 of this sheet I have updated the API so that L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault> 
-is a stand alone class (not a role).  This more closely follows Spreadsheet::ParseExcel.  And 
-incidentally probably makes building alternate formatting modules easier.  I<The formatters will 
-still not exchange back and forth between L<Spreadsheet::ParseExcel::FmtDefault> and back since 
-they are both built to interface with fundamentally different architecture.>  This also affects 
-the role L<Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings> and how it is consumed.  If 
-you wrote your own formatter for this package that interfaces in the old way I would be willing 
+for the formatter class.  I suppose this was, in part, laziness.  In an effort to partially 
+comply with goal #2 of this sheet I have updated the API so that it the formatter is a stand-alone 
+class.  For details of the implemenation see L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault/CLASS DESCRIPTION> 
+This more closely follows Spreadsheet::ParseExcel, and incidentally probably makes building alternate 
+formatting modules easier.  I<The formatters will still not exchange back and forth between 
+L<Spreadsheet::ParseExcel::FmtDefault> and back since they are both built to interface with 
+fundamentally different architecture.>  This also affects the role 
+L<Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings> and how it is consumed.  If 
+you wrote your own formatter for this package for the old way I would be willing 
 to provide troubleshooting support for the transition to the the new API.  However if you are 
-setting specific formats today using get_defined_excel_format( $pos ) it should still work.  
-(Moose delegation is a wonderful thing) This warning will be removed on 2/1/2016.
+setting specific formats today using set_defined_excel_format_list you should be able to switch to
+L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault/set_defined_excel_formats( %args )> or use the 
+attribute L<Spreadsheet::XLSX::Reader::LibXML::FmtDefault/defined_excel_translations>.    B<This warning 
+will be removed on 2/1/2016.>
 
 =head2 Attributes
 
@@ -2176,6 +2179,8 @@ L<empty_is_end|/empty_is_end> => 1
 L<group_return_type|/group_return_type> => 'value'
 
 L<cache_positions|/cache_positions> => 1
+
+L<from_the_edge|/from_the_edge> => 0,
 
 =back
 

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/Cell.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/Cell.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::Cell;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 $| = 1;
 use 5.010;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/CellToColumnRow.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/CellToColumnRow.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::CellToColumnRow;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use	Moose::Role;
 requires

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/Error.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/Error.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::Error;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use Moose;
 use Carp qw( cluck );

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/FmtDefault.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/FmtDefault.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::FmtDefault;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 ###LogSD	warn "You uncovered logging statements for Spreadsheet::XLSX::Reader::LibXML::FmtDefault-$VERSION";
 
 use	5.010;
@@ -303,6 +303,8 @@ $position
 
 B<Returns:> an excel format string
 
+B<Delegated to the workbook class:> yes
+
 =back
 
 =head3 set_defined_excel_formats( %args )
@@ -333,6 +335,8 @@ B<Accepts:> nothing
 
 B<Returns:> $count (an integer)
 
+B<Delegated to the workbook class:> yes
+
 =back
 
 =head3 change_output_encoding( $string )
@@ -351,6 +355,8 @@ B<Accepts:> a perl coded string
 
 B<Returns:> the converted $string decoded to the L<defined format|/target_encoding>
 
+B<Delegated to the workbook class:> yes
+
 =back
 
 =head3 get_defined_conversion( $position )
@@ -360,6 +366,8 @@ Defined in L<Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings/get_defi
 =head3 parse_excel_format_string( $format_string, $name )
 
 Defined in L<Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings/parse_excel_format_string( $string, $name )>
+
+B<Delegated to the workbook class:> no
 
 =head2 Attributes
 

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/ParseExcelFormatStrings.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/ParseExcelFormatStrings.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::ParseExcelFormatStrings;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use 5.010;
 use Moose::Role;
@@ -1743,6 +1743,8 @@ none is given
 B<Returns:> a L<Type::Tiny> object with type coercions and pre-filters set for each input type 
 from the formatting string
 
+B<Delegated to the workbook class:> yes
+
 =back
 
 =head3 get_defined_conversion( $position )
@@ -1757,6 +1759,8 @@ B<Accepts:> an Excel format position
 
 B<Returns:> a L<Type::Tiny> object with type coercions and pre-filters set for each input type 
 from the formatting string
+
+B<Delegated to the workbook class:> no
 
 =back
 
@@ -1790,6 +1794,8 @@ B<get_epoch_year>
 
 B<Definition:> returns the value of the attribute
 
+B<Delegated to the workbook class:> no
+
 =back
 
 B<set_epoch_year>
@@ -1797,6 +1803,8 @@ B<set_epoch_year>
 =over
 
 B<Definition:> sets the value of the attribute
+
+B<Delegated to the workbook class:> no
 
 =back
 
@@ -1827,6 +1835,8 @@ B<get_date_behavior>
 
 B<Definition:> returns the value of the attribute
 
+B<Delegated to the workbook class:> yes
+
 =back
 
 =back
@@ -1841,6 +1851,8 @@ B<Definition:> sets the attribute value (only L<new|/cache_formats> coercions
 are affected)
 
 B<Accepts:> Boolean values
+
+B<Delegated to the workbook class:> yes
 
 =back
 
@@ -1868,6 +1880,8 @@ B<get_cache_behavior>
 
 B<Definition:> returns the value of the attribute
 
+B<Delegated to the workbook class:> inherited
+
 =back
 
 B<set_cache_behavior>
@@ -1877,6 +1891,8 @@ B<set_cache_behavior>
 B<Definition:> sets the value of the attribute
 
 B<Range:> Boolean 1 = cache formats, 0 = Don't cache formats
+
+B<Delegated to the workbook class:> inherited
 
 =back
 

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/Types.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/Types.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::Types;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 		
 use strict;
 use warnings;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/Worksheet.pod
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/Worksheet.pod
@@ -120,25 +120,34 @@ per the attribute L<Spreadsheet::XLSX::Reader::LibXML/group_return_type>.
 
 =back
 
-=head3 set_headers( @header_row_list )
+=head3 set_headers( @header_row_list [ \&header_scrubber ] )
 
 =over
 
 B<Definition:> This function is used to set headers used in the function 
 L<fetchrow_hashref|/fetchrow_hashref( $row )>.  It accepts a list of row numbers that 
 will be collated into a set of headers used to build the hashref for each row.
-The header rows are coallated in sequence with the first number in the list taking 
-precedence.  The list is also used to set the lowest row of the headers in the table.  
-All rows at that level and higher will be considered out of the table and will return 
-'undef' while setting the error instance.  If some of the columns do not have values 
-then the instance will auto generate unique headers for each empty header column to 
-fill out the header ref.  Please pay attention to the fact that this method is also 
-affected by the attribute L<Spreadsheet::XLSX::Reader::LibXML/group_return_type> with 
-one exception.  If that attribute is set to 'instance' the headers will be composed of 
-the converted 'value's of each cell rather than either the instance pointer string or 
-the 'unformatted' value.
+The header rows are coallated in sequence with the first number taking precedence.  
+The list is also used to set the lowest row of the headers in the table.  All rows 
+at that level and higher will be considered out of the table and will return undef 
+while setting the error instance.  If some of the columns do not have values then 
+the instance will auto generate unique headers for each empty header column to fill 
+out the header ref.  [ optionally: it is possible to pass a coderef to scrub the 
+headers so they make some sence. for example; ]
 
-B<Accepts:> a list of row numbers
+	my $scrubber = sub{
+		my $input = $_[0];
+		$input =~ s/\n//g if $input;
+		$input =~ s/\s/_/g if $input;
+		return $input;
+	};
+	$self->set_headers( 2, 1, $scrubber ); # Called internally as $new_value = $scrubber->( $old_value );
+	# Returns/stores the headers set at row 2 and 1 with values from row 2 taking precedence
+	#  Then it scrubs the values by removing newlines and replacing spaces with underscores.
+
+B<Accepts:> a list of row numbers (modified as needed by the attribute state of 
+L<Spreadsheet::XLSX::Reader::LibXML/count_from_zero>) and an optional L<closure
+|http://www.perl.com/pub/2002/05/29/closure.html>.
 
 B<Returns:> an array ref of the built headers for review
 

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::XMLReader;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use 5.010;
 use Moose;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/CalcChain.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/CalcChain.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::XMLReader::CalcChain;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use 5.010;
 use Moose;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Chartsheet.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Chartsheet.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::XMLReader::Chartsheet;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 
 use	5.010;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/SharedStrings.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/SharedStrings.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::XMLReader::SharedStrings;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use 5.010;
 use Moose;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Styles.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Styles.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::XMLReader::Styles;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use 5.010;
 use Moose;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Worksheet.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/Worksheet.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::XMLReader::Worksheet;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use	5.010;
 use	Moose;

--- a/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/XMLToPerlData.pm
+++ b/lib/Spreadsheet/XLSX/Reader/LibXML/XMLReader/XMLToPerlData.pm
@@ -1,5 +1,5 @@
 package Spreadsheet::XLSX::Reader::LibXML::XMLReader::XMLToPerlData;
-use version; our $VERSION = qv('v0.38.4');
+use version; our $VERSION = qv('v0.38.6');
 
 use	Moose::Role;
 use	Carp 'confess';


### PR DESCRIPTION
	! Some general documentation updates for the FmtDefault class that were not done correctly for the last release
		Doh!
	+ Added the possibility of passing a closure to the set_headers for header value scrubbing
	+ Adjusted the :just_the_data flag
		cache_positions   => 1, (documented as added but not added last commit)
		from_the_edge     => 0,